### PR TITLE
only load photos at viewdidload not viewdidappear

### DIFF
--- a/DBCamera/Controllers/DBCameraLibraryViewController.m
+++ b/DBCamera/Controllers/DBCameraLibraryViewController.m
@@ -91,6 +91,8 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 
     [self.view addSubview:self.loading];
     [self.view setGestureRecognizers:_pageViewController.gestureRecognizers];
+	
+	[self loadLibraryGroups];
 }
 
 - (void) viewWillAppear:(BOOL)animated
@@ -106,7 +108,6 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 {
     [super viewDidAppear:animated];
     
-    [self loadLibraryGroups];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:)
                                                  name:UIApplicationDidBecomeActiveNotification object:[UIApplication sharedApplication]];


### PR DESCRIPTION
I noticed when you come back to cameraLibrary in a navigationController it reloads and scrollstotop which is annoying if the user just wants to repick a photo.

You already have applicationdidbecomeactive listeners(I love that you thought of this) so that takes care of the other scenario where app woke up from background and pics may have changed. It should be safe to now only reload at load time of view controller.
