### PR TITLE
Initializers now return instancetype, more friendly to subclassing

### DIFF
--- a/DBCamera/Controllers/DBCameraViewController.h
+++ b/DBCamera/Controllers/DBCameraViewController.h
@@ -60,14 +60,14 @@
  *
  *  @return A DBCameraViewController
  */
-+ (DBCameraViewController *) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate;
++ (instancetype) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate;
 
 /**
  *  The init class method
  *
  *  @return A DBCameraViewController
  */
-+ (DBCameraViewController *) init;
++ (instancetype) init;
 
 /**
  *  The init method with a DBCameraViewControllerDelegate and a custom camera view
@@ -77,5 +77,5 @@
  *
  *  @return A DBCameraViewController
  */
-- (id) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate cameraView:(id)camera;
+- (instancetype) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate cameraView:(id)camera;
 @end

--- a/DBCamera/Controllers/DBCameraViewController.m
+++ b/DBCamera/Controllers/DBCameraViewController.m
@@ -46,35 +46,35 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 
 #pragma mark - Life cycle
 
-+ (DBCameraViewController *) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate
++ (instancetype) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate
 {
     return [[self alloc] initWithDelegate:delegate cameraView:nil];
 }
 
-+ (DBCameraViewController *) init
++ (instancetype) init
 {
     return [[self alloc] initWithDelegate:nil cameraView:nil];
 }
 
-- (id) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate cameraView:(id)camera
+- (instancetype) initWithDelegate:(id<DBCameraViewControllerDelegate>)delegate cameraView:(id)camera
 {
     self = [super init];
-    
+
     if ( self ) {
         _processingPhoto = NO;
         _deviceOrientation = UIDeviceOrientationPortrait;
         if ( delegate )
             _delegate = delegate;
-        
+
         if ( camera )
             [self setCustomCamera:camera];
 
         [self setUseCameraSegue:YES];
-        
+
         [self setTintColor:[UIColor whiteColor]];
         [self setSelectedTintColor:[UIColor cyanColor]];
     }
-    
+
     return self;
 }
 
@@ -82,27 +82,27 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
-    
+
     [self.view setBackgroundColor:[UIColor blackColor]];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackground:)
                                                  name:UIApplicationDidEnterBackgroundNotification object:nil];
-    
+
     NSError *error;
     if ( [self.cameraManager setupSessionWithPreset:AVCaptureSessionPresetPhoto error:&error] ) {
         if ( self.customCamera ) {
             if ( [self.customCamera respondsToSelector:@selector(previewLayer)] ) {
                 [(AVCaptureVideoPreviewLayer *)[self.customCamera valueForKey:@"previewLayer"] setSession:self.cameraManager.captureSession];
-                
+
                 if ( [self.customCamera respondsToSelector:@selector(delegate)] )
                     [self.customCamera setValue:self forKey:@"delegate"];
             }
-            
+
             [self.view addSubview:self.customCamera];
         } else
             [self.view addSubview:self.cameraView];
     }
-    
+
     id camera =_customCamera ?: _cameraView;
     [camera insertSubview:self.cameraGridView atIndex:1];
 }
@@ -111,7 +111,7 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 {
     [super viewDidAppear:animated];
     [self.cameraManager performSelector:@selector(startRunning) withObject:nil afterDelay:0.0];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(rotationChanged:)
                                                  name:@"UIDeviceOrientationDidChangeNotification"
@@ -130,7 +130,7 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 {
     [super viewWillDisappear:animated];
     [self.cameraManager performSelector:@selector(stopRunning) withObject:nil afterDelay:0.0];
-    
+
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"UIDeviceOrientationDidChangeNotification" object:nil];
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
 }
@@ -180,7 +180,7 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
         [_cameraView defaultInterface];
         [_cameraView setDelegate:self];
     }
-    
+
     return _cameraView;
 }
 
@@ -190,7 +190,7 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
         _cameraManager = [[DBCameraManager alloc] init];
         [_cameraManager setDelegate:self];
     }
-    
+
     return _cameraManager;
 }
 
@@ -203,7 +203,7 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
         [_cameraGridView setNumberOfRows:2];
         [_cameraGridView setAlpha:0];
     }
-    
+
     return _cameraGridView;
 }
 
@@ -264,22 +264,22 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 - (void) captureImageDidFinish:(UIImage *)image withMetadata:(NSDictionary *)metadata
 {
     _processingPhoto = NO;
-    
+
     NSMutableDictionary *finalMetadata = [NSMutableDictionary dictionaryWithDictionary:metadata];
     finalMetadata[@"DBCameraSource"] = @"Camera";
-    
+
     if ( !self.useCameraSegue ) {
         if ( [_delegate respondsToSelector:@selector(camera:didFinishWithImage:withMetadata:)] )
             [_delegate camera:self didFinishWithImage:image withMetadata:finalMetadata];
     } else {
         CGFloat newW = 256.0;
         CGFloat newH = 340.0;
-        
+
         if ( image.size.width > image.size.height ) {
             newW = 340.0;
             newH = ( newW * image.size.height ) / image.size.width;
         }
-        
+
         DBCameraSegueViewController *segue = [[DBCameraSegueViewController alloc] initWithImage:image thumb:[UIImage returnImage:image withSize:(CGSize){ newW, newH }]];
         [segue setTintColor:self.tintColor];
         [segue setSelectedTintColor:self.selectedTintColor];
@@ -288,7 +288,7 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
         [segue setDelegate:self.delegate];
         [segue setCapturedImageMetadata:finalMetadata];
         [segue setCameraSegueConfigureBlock:self.cameraSegueConfigureBlock];
-        
+
         [self.navigationController pushViewController:segue animated:YES];
     }
 }
@@ -341,9 +341,9 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 {
     if ( _processingPhoto )
         return;
-    
+
     _processingPhoto = YES;
-    
+
     [self.cameraManager captureImageForDeviceOrientation:_deviceOrientation];
 }
 


### PR DESCRIPTION
The original initializers have return type `DBCameraViewController`, which creates warnings in subclass initializers because "the type is not compatible". Changing the type signature to `instancetype` allows automatic type detection, and resolves the warning in subclass initializers.
