### PR TITLE
Show filters also when force quad crop is used

### DIFF
--- a/DBCamera/Controllers/DBCameraSegueViewController.m
+++ b/DBCamera/Controllers/DBCameraSegueViewController.m
@@ -179,8 +179,12 @@ static const CGSize kFilterCellSize = { 75, 90 };
 {
     _cropMode = cropMode;
     [self.frameView setHidden:!_cropMode];
-    [self.bottomBar setHidden:!_cropMode];
-    [self.filtersView setHidden:_cropMode];
+    
+    // Only hide filters if quad crop is not forced, otherwise filters are not accessible
+    if (!_forceQuadCrop) {
+        [self.bottomBar setHidden:!_cropMode];
+        [self.filtersView setHidden:_cropMode];
+    }
 }
 
 - (DBCameraFiltersView *) filtersView


### PR DESCRIPTION
Currently filters are not accessible if force quad mode is set to YES. 
