### PR TITLE
allow _customCamera to autorotate correctly

### DIFF
--- a/DBCamera/Controllers/DBCameraViewController.m
+++ b/DBCamera/Controllers/DBCameraViewController.m
@@ -238,8 +238,9 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    _cameraView.frame = CGRectMake(0, 0, size.width, size.height);
-    _cameraView.previewLayer.frame = CGRectMake(0, 0, size.width, size.height);
+    DBCameraView *camera = _customCamera ?: _cameraView;
+    camera.frame = CGRectMake(0, 0, size.width, size.height);
+    camera.previewLayer.frame = CGRectMake(0, 0, size.width, size.height);
 }
 
 + (AVCaptureVideoOrientation)interfaceOrientationToVideoOrientation:(UIInterfaceOrientation)orientation {
@@ -265,9 +266,10 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
     [super viewDidLayoutSubviews];
     
     AVCaptureVideoOrientation videoOrientation = [[self class] interfaceOrientationToVideoOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
-    if (_cameraView.previewLayer.connection.supportsVideoOrientation
-        && _cameraView.previewLayer.connection.videoOrientation != videoOrientation) {
-        _cameraView.previewLayer.connection.videoOrientation = videoOrientation;
+    DBCameraView *camera = _customCamera ?: _cameraView;
+    if (camera.previewLayer.connection.supportsVideoOrientation
+        && camera.previewLayer.connection.videoOrientation != videoOrientation) {
+        camera.previewLayer.connection.videoOrientation = videoOrientation;
     }
 }
 


### PR DESCRIPTION
If DBCameraViewController is initialized with ```-initWithDelegate:cameraView:```, then during autorotation, we shouldn't be adjusting the frame of ```_cameraView``` (which is nil) but instead ```_customCamera```.

Makes the ?potentially unsafe? assumption that ```_customCamera``` is a subclass of ```DBCameraView``` or at least has a ```previewLayer property```, but that assumption has already been made several times in ```DBCameraViewController``` so I didn't feel that adding additional defensive code here would actually save a crash. I'm happy to add be more defensive if requested.