### PR TITLE
Update DBCameraManager.m

### DIFF
--- a/DBCamera/Managers/DBCameraManager.m
+++ b/DBCamera/Managers/DBCameraManager.m
@@ -146,7 +146,7 @@
              UIImage *image = [[UIImage alloc] initWithData:imageData];
              
              CFDictionaryRef metadata = CMCopyDictionaryOfAttachments(NULL, imageDataSampleBuffer, kCMAttachmentMode_ShouldPropagate);
-             NSDictionary *meta = (__bridge NSDictionary *)(metadata);
+             NSDictionary *meta = [[NSDictionary alloc] initWithDictionary:(__bridge NSDictionary *)(metadata)];
              CFRelease(metadata);
              
              if ( [delegateBlock respondsToSelector:@selector(captureImageDidFinish:withMetadata:)] )


### PR DESCRIPTION
NSDictionary *meta = (__bridge NSDictionary *)(metadata); 
CFRelease(metadata);
leak warning. here metadata is assigned to meta. When metadata released meta object wont have any value too.

So it is better this way: 
NSDictionary *meta = [[NSDictionary alloc] initWithDictionary:(__bridge NSDictionary *)(metadata)];
Then meta has its own object even metadata is released meta is remains retained.