### PR TITLE
Bug fix on pinch gesture when cropping image.

### DIFF
--- a/DBCamera/Controllers/DBCameraBaseCropViewController.m
+++ b/DBCamera/Controllers/DBCameraBaseCropViewController.m
@@ -318,9 +318,7 @@ static const NSTimeInterval kAnimationIntervalTransform = 0.2;
         CGAffineTransform transform =  CGAffineTransformTranslate(self.imageView.transform, deltaX, deltaY);
         transform = CGAffineTransformScale(transform, recognizer.scale, recognizer.scale);
         transform = CGAffineTransformTranslate(transform, -deltaX, -deltaY);
-        self.scale *= recognizer.scale;
-        self.imageView.transform = transform;
-        
+        self.imageView.transform = CGAffineTransformScale(transform, recognizer.scale, recognizer.scale);
         recognizer.scale = 1;
         
         [self checkBoundsWithTransform:transform];


### PR DESCRIPTION
Once the crop rect reached the image's edge, the image cannot be zoom out.