### PR TITLE
Simple missing camera permission handling, verify videoConnection before using it, (>= iOS 7.0)

### DIFF
--- a/DBCamera/Controllers/DBCameraViewController.m
+++ b/DBCamera/Controllers/DBCameraViewController.m
@@ -386,6 +386,25 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 
     _processingPhoto = YES;
 
+    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_7_0) {
+        AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+
+        if (status == AVAuthorizationStatusDenied || status == AVAuthorizationStatusRestricted) {
+            [[[UIAlertView alloc] initWithTitle:DBCameraLocalizedStrings(@"general.error.title")
+                                        message:DBCameraLocalizedStrings(@"cameraimage.nopolicy")
+                                       delegate:nil
+                              cancelButtonTitle:@"Ok"
+                              otherButtonTitles:nil, nil] show];
+
+            return;
+        }
+        else if (status == AVAuthorizationStatusNotDetermined) {
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:nil];
+
+            return;
+        }
+    }
+
     [self.cameraManager captureImageForDeviceOrientation:_deviceOrientation];
 }
 

--- a/DBCamera/Localizations/en.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/en.lproj/DBCamera.strings
@@ -12,6 +12,9 @@
 "general.error.title" = "Attention";
 "general.button.cancel" = "Cancel";
 
+"cameraimage.nopolicy" = "Please enable the permissions in order to use your Camera. Check your permissions in Settings > Privacy > Camera";
+"cameraimage.noconnection" = "Could not connect to camera. Please check your permissions in Settings > Privacy > Camera";
+
 "pickerimage.nopolicy" = "Please enable the permissions in order to use your Photo Library. Check your permissions in Settings > Privacy > Photos";
 "pickerimage.nophoto" = "There are no images in your Library";
 

--- a/DBCamera/Localizations/es.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/es.lproj/DBCamera.strings
@@ -19,3 +19,5 @@
 
 "cropmode.title" = "Aspect Ratio";
 "cropmode.square" = "Cuadrado";
+"cameraimage.nopolicy" = "cameraimage.nopolicy";
+"cameraimage.noconnection" = "cameraimage.noconnection";

--- a/DBCamera/Localizations/it.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/it.lproj/DBCamera.strings
@@ -19,3 +19,5 @@
 
 "cropmode.title" = "Aspect Ratio";
 "cropmode.square" = "Quadrato";
+"cameraimage.nopolicy" = "cameraimage.nopolicy";
+"cameraimage.noconnection" = "cameraimage.noconnection";

--- a/DBCamera/Localizations/pt.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/pt.lproj/DBCamera.strings
@@ -20,3 +20,5 @@
 
 "cropmode.title" = "Aspect Ratio";
 "cropmode.square" = "Quadrado";
+"cameraimage.nopolicy" = "cameraimage.nopolicy";
+"cameraimage.noconnection" = "cameraimage.noconnection";

--- a/DBCamera/Localizations/ru.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/ru.lproj/DBCamera.strings
@@ -19,3 +19,5 @@
 
 "cropmode.title" = "Соотношение сторон";
 "cropmode.square" = "Квадрат";
+"cameraimage.nopolicy" = "cameraimage.nopolicy";
+"cameraimage.noconnection" = "cameraimage.noconnection";

--- a/DBCamera/Localizations/sv-SE.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/sv-SE.lproj/DBCamera.strings
@@ -19,3 +19,5 @@
 
 "cropmode.title" = "Bildförhållande";
 "cropmode.square" = "Kvadrat";
+"cameraimage.nopolicy" = "cameraimage.nopolicy";
+"cameraimage.noconnection" = "cameraimage.noconnection";

--- a/DBCamera/Localizations/tr.lproj/DBCamera.strings
+++ b/DBCamera/Localizations/tr.lproj/DBCamera.strings
@@ -19,3 +19,5 @@
 
 "cropmode.title" = "Kırpma Oranı";
 "cropmode.square" = "Kare";
+"cameraimage.nopolicy" = "cameraimage.nopolicy";
+"cameraimage.noconnection" = "cameraimage.noconnection";

--- a/DBCamera/Managers/DBCameraManager.m
+++ b/DBCamera/Managers/DBCameraManager.m
@@ -111,6 +111,20 @@
 - (void) captureImageForDeviceOrientation:(UIDeviceOrientation)deviceOrientation
 {
     AVCaptureConnection *videoConnection = [DBCameraManager connectionWithMediaType:AVMediaTypeVideo fromConnections:_stillImageOutput.connections];
+
+    if (!videoConnection) {
+        NSError *error = [NSError errorWithDomain:@"DBCamera"
+                                             code:-1
+                                         userInfo:@{
+                                                 NSLocalizedFailureReasonErrorKey : @"cameraimage.noconnection"
+                                         }];
+
+        if ([_delegate respondsToSelector:@selector(captureImageFailedWithError:)]) {
+            [_delegate captureImageFailedWithError:error];
+        }
+
+        return;
+    }
     
     if ( [videoConnection isVideoOrientationSupported] ) {
         switch (deviceOrientation) {
@@ -133,7 +147,7 @@
     }
     
     [videoConnection setVideoScaleAndCropFactor:_maxScale];
-    
+
     __weak AVCaptureSession *captureSessionBlock = _captureSession;
     __weak id<DBCameraManagerDelegate>delegateBlock = _delegate;
     


### PR DESCRIPTION
Tapping take image button causes a crash if there are no permission for camera access.