### PR TITLE
Fix a crash when DBCameraLibraryViewController has been released ...

### DIFF
--- a/DBCamera/Controllers/DBCameraLibraryViewController.m
+++ b/DBCamera/Controllers/DBCameraLibraryViewController.m
@@ -156,42 +156,54 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
     __block NSUInteger blockPresentationIndex = _presentationIndex;
     __block BOOL isEnumeratingGroupsBlock = _isEnumeratingGroups;
     isEnumeratingGroupsBlock = YES;
-    
+
     [[DBLibraryManager sharedInstance] loadGroupsAssetWithBlock:^(BOOL success, NSArray *items) {
-        if ( success ) {
+        if (!blockSelf) {
+            return;
+        }
+
+        if (success) {
             [blockSelf.loading removeFromSuperview];
-            if ( items.count > 0) {
+
+            if (items.count > 0) {
                 [blockItems removeAllObjects];
                 [blockItems addObjectsFromArray:items];
                 [blockContainerMapping removeAllObjects];
-                
-                for ( NSUInteger i=0; i<blockItems.count; i++ ) {
+
+                for (NSUInteger i = 0; i < blockItems.count; i++) {
                     DBCameraCollectionViewController *vc = [[DBCameraCollectionViewController alloc] initWithCollectionIdentifier:kItemIdentifier];
                     [vc setCurrentIndex:i];
-                    [vc setItems:(NSArray *)blockItems[i][@"groupAssets"]];
+                    [vc setItems:(NSArray *) blockItems[i][@"groupAssets"]];
                     [vc setCollectionControllerDelegate:blockSelf];
-                    [blockContainerMapping setObject:vc forKey:@(i)];
+
+                    blockContainerMapping[@(i)] = vc;
                 }
-                
+
                 NSInteger usedIndex = [blockSelf indexForSelectedItem];
-                blockPresentationIndex = usedIndex >= 0 ? usedIndex : 0;
+                blockPresentationIndex = (NSUInteger) (usedIndex >= 0 ? usedIndex : 0);
+
                 [blockSelf setNavigationTitleAtIndex:blockPresentationIndex];
                 [blockSelf setSelectedItemID:blockItems[blockPresentationIndex][@"propertyID"]];
-                [pageViewControllerBlock setViewControllers:@[ blockContainerMapping[@(blockPresentationIndex)] ]
+
+                [pageViewControllerBlock setViewControllers:@[blockContainerMapping[@(blockPresentationIndex)]]
                                                   direction:UIPageViewControllerNavigationDirectionForward
                                                    animated:NO
                                                  completion:nil];
-                
+
                 [UIView animateWithDuration:.3 animations:^{
                     [pageViewControllerBlock.view setAlpha:1];
                 }];
             } else {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [[[UIAlertView alloc] initWithTitle:DBCameraLocalizedStrings(@"general.error.title") message:DBCameraLocalizedStrings(@"pickerimage.nophoto") delegate:nil cancelButtonTitle:@"Ok" otherButtonTitles:nil, nil] show];
+                    [[[UIAlertView alloc] initWithTitle:DBCameraLocalizedStrings(@"general.error.title")
+                                                message:DBCameraLocalizedStrings(@"pickerimage.nophoto")
+                                               delegate:nil
+                                      cancelButtonTitle:@"Ok"
+                                      otherButtonTitles:nil, nil] show];
                 });
             }
         }
-        
+
         isEnumeratingGroupsBlock = NO;
     }];
 }
@@ -205,7 +217,8 @@ NSLocalizedStringFromTable(key, @"DBCamera", nil)
 - (NSInteger) indexForSelectedItem
 {
     __weak typeof(self) blockSelf = self;
-    __block NSUInteger blockIndex = -1;
+    __block NSInteger blockIndex = -1;
+
     [_items enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         if ( [blockSelf.selectedItemID isEqualToString:obj[@"propertyID"]] ) {
             *stop = YES;


### PR DESCRIPTION
…but loadGroupsAssetWithBlock is executed
(might happen i.e. when coming back to app and view stack is popped)

- Check that blockSelf isn't released before trying to use it in loadGroupsAssetWithBlock
- Modern style syntax and minor formatting
- Make code more intuitive: use NSInteger type instead of NSUInteger in indexForSelectedItem when assigning value -1