### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DBCamera is a simple custom camera with AVFoundation.
 
-##Getting Started
+## Getting Started
 
 ### Installation
 
@@ -159,7 +159,7 @@ For simple customizations, you can customize the built-in camera view by sending
 }
 ```
 
-##Customize the Segue View controller
+## Customize the Segue View controller
 For a simple customization, you can use the block ``` cameraSegueConfigureBlock ```
 ```objective-c
 #import "DBCameraSegueViewController.h"
@@ -275,17 +275,17 @@ You can also create a custom interface, using a subclass of DBCameraView
 }
 ```
 
-###iOS Min Required
+### iOS Min Required
 6.0
 
-###Version
+### Version
 2.4.1
 
-###Created By
+### Created By
 
 [Daniele Bogo](https://github.com/danielebogo)
 
-###Credits
+### Credits
 
 [mkcode](https://github.com/mkcode),
 [Jack](https://github.com/xhzengAIB),


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
